### PR TITLE
finds general html attributes and uses them as props in react

### DIFF
--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
           Edit the button text:
           <Input
             value={buttonText}
-            onInput={(e) => setButtonText(e.detail.value)}
+            onInput={(e: CustomEvent) => setButtonText(e.detail.value)}
           />
         </label>
         {buttonText && (


### PR DESCRIPTION
Part of https://github.com/brave/leo/issues/407

Context of this PR is in this review comment: https://github.com/brave/leo/pull/440#pullrequestreview-1683275414
> The main thing we might be missing is the ability to accept standard HTML events. When we wrap these in a WebComponent, it actually supports all the standard events (onClick, onMouseEnter, onMouseDown, onKeyDown ect), so we should make sure we are still able to accept those events too

To address the comment made above by @fallaciousreasoning ☝🏻, the code in this PR finds the html types svelte uses from the builds resulting type file and uses it to generate prop type definitions for the react component. As an example, for the Button component this script looks in `types/components/button/button.svelte.d.ts` and finds these types: `HTMLElement, HTMLButtonElement, HTMLAnchorElement`. _Note: doing it this way also allows other standard html attributes on the component (not just events), I don't think that's all that big of a deal though_

This works when you import and use `SvelteHTMLElements` like in `button.svelte`:

```svelte
<script lang="ts">
  import { createEventDispatcher } from 'svelte'
  import type { SvelteHTMLElements } from 'svelte/elements'
  import type * as Props from './props'
   ...
  type ButtonProps = CommonProps &
    Omit<Partial<SvelteHTMLElements['button']>, ExcludedProps> & {
      isDisabled?: Disabled
      href?: never
    }

  type LinkProps = CommonProps &
    Omit<Partial<SvelteHTMLElements['a']>, ExcludedProps> & {
      href: Href
    }

  type $$Props = LinkProps | ButtonProps
  ...
```

Here's a before and after of the generated type:

Before:
```ts
export default function ButtonReact<
  Href extends string | undefined,
  Disabled extends undefined extends Href ? boolean : undefined
>(props: React.PropsWithChildren<ButtonProps<Href, Disabled>>): JSX.Element;

```

After:
```ts
export default function ButtonReact<
  Href extends string | undefined,
  Disabled extends undefined extends Href ? boolean : undefined
>(
  props: React.PropsWithChildren<
    | React.HTMLAttributes<HTMLElement | HTMLButtonElement | HTMLAnchorElement>
    | ButtonProps<Href, Disabled>
  >
): JSX.Element;

```

#### Screencaps
Before:

https://github.com/benjaminknox/leo/assets/5668789/65209086-b4ef-4a73-b7bf-5b64f67a2dc5

After:

https://github.com/benjaminknox/leo/assets/5668789/e30e46c1-408d-41c6-a132-417ed7004102



