### PR TITLE
[Tooltip]: adds prop for width of tooltip

### DIFF
--- a/src/components/tooltip/tooltip.svelte
+++ b/src/components/tooltip/tooltip.svelte
@@ -18,6 +18,12 @@
   export let offset: number = 8
   export let mode: Mode = 'mini'
 
+  /** The width of the tooltip */
+  export let width: number | undefined = undefined
+
+  let tooltipWidth = width && `${width}px`
+  let whiteSpace = tooltipWidth ? 'normal' : 'nowrap';
+
   /** The length of time the tooltip is open in ms after mouse leave of
    * the trigger or tooltip */
   export let mouseleaveTimeout: number = 150
@@ -114,7 +120,7 @@
   }
 </script>
 
-<div class="leo-tooltip">
+<div class="leo-tooltip" style="--width: {tooltipWidth}; --white-space: {whiteSpace};">
   {#key visibleInternal}
     <Floating
       target={trigger}
@@ -180,7 +186,8 @@
     border-radius: var(--radius);
     border: var(--border-width) solid var(--border-color);
     font: var(--leo-font-primary-default-regular);
-    white-space: nowrap;
+    white-space: var(--white-space);
+    width: var(--width);
   }
 
   .leo-tooltip .tooltip {

--- a/src/components/tooltip/tooltip.svelte
+++ b/src/components/tooltip/tooltip.svelte
@@ -180,6 +180,7 @@
     border-radius: var(--radius);
     border: var(--border-width) solid var(--border-color);
     font: var(--leo-font-primary-default-regular);
+    white-space: nowrap;
   }
 
   .leo-tooltip .tooltip {


### PR DESCRIPTION
# What?

Adds a width property to the tooltip and adds `white-space: nowrap` for when the width doesn't exist. We want the text to wrap when there is a width constraint, but not when there is a defined width associated.

It address an issue brought up by @AlanBreck  in this comment: https://github.com/brave/leo/pull/488#pullrequestreview-1755645703

without width definition:
![image](https://github.com/benjaminknox/leo/assets/5668789/c7215c89-2e4d-4f92-a491-ef5647a5b27f)

with the width defined:
![image](https://github.com/benjaminknox/leo/assets/5668789/3590d63a-2ad3-4f3a-9f04-e4c2c0e76be6)
