### PR TITLE
[types]: Omit children from svelte types in react bindings

### DIFF
--- a/src/components/buttonMenu/buttonMenu.svelte
+++ b/src/components/buttonMenu/buttonMenu.svelte
@@ -1,11 +1,12 @@
 <script context="module" lang="ts">
-  import type { HTMLAttributes } from 'svelte/elements'
+  import type { HTMLAttributes } from '../types/attributes'
+
   declare global {
     namespace JSX {
       interface IntrinsicElements {
         'leo-menu-item': HTMLAttributes<HTMLElement> & {
           key?: string | number | null
-          children?: any
+          children?: string | Element[]
           onClick?: EventListener
         }
       }

--- a/src/components/dropdown/dropdown.svelte
+++ b/src/components/dropdown/dropdown.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-  import type { HTMLAttributes } from 'svelte/elements'
+  import type { HTMLAttributes } from '../types/attributes'
   declare global {
     namespace JSX {
       interface IntrinsicElements {
@@ -9,7 +9,7 @@
           key?: string | number | null
 
           value?: string
-          children?: any
+          children?: string | Element[]
         }
       }
     }

--- a/src/components/menu/menu.svelte
+++ b/src/components/menu/menu.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-  import type { HTMLAttributes } from 'svelte/elements'
+  import type { HTMLAttributes } from '../types/attributes'
   declare global {
     namespace JSX {
       interface IntrinsicElements {
@@ -7,13 +7,13 @@
           // Note: This should line up with Reacts key type, but we don't want
           // to depend on React in this layer, so we just define it manually.
           key?: string | number | null
-          children?: any
+          children?: string | Element[]
           onClick?: EventListener
         }
         'leo-option': HTMLAttributes<HTMLElement> & {
           key?: string | number | null
           value?: string
-          children?: any
+          children?: string | Element[]
         }
       }
     }

--- a/src/scripts/gen-react-bindings.js
+++ b/src/scripts/gen-react-bindings.js
@@ -73,7 +73,7 @@ export * from '../web-components/${fileNameWithoutExtension}.js'
 import type * as React from 'react'
 import type { ReactProps } from '../src/components/svelte-react'
 import type { ${componentName}Props as SvelteProps } from '../types/src/components/${containingFolder}/${fileName}';
-export type ${componentName}Props${funcConstraints} = ReactProps<SvelteProps${propParams}>;
+export type ${componentName}Props${funcConstraints} = ReactProps<Omit<SvelteProps${propParams}, 'children'>>;
 export default function ${componentName}${funcConstraints}(props: React.PropsWithChildren<${componentName}Props${propParams}>): JSX.Element
 
 // As we don't currently have type definitions for the web components, export

--- a/src/types/attributes.ts
+++ b/src/types/attributes.ts
@@ -1,0 +1,6 @@
+import type { HTMLAttributes as SvelteHTMLAttributes } from 'svelte/elements'
+
+export type HTMLAttributes<T extends EventTarget> = Omit<
+  SvelteHTMLAttributes<T>,
+  'children'
+>


### PR DESCRIPTION
# What?

In the svelte 5 react bindings, the children prop type on components resolve to `Snippet<[]>` and we get type errors on something like this:

```tsx
 <LeoButton href="#foo">Link button!</LeoButton>
// or
<leo-menu-item onClick={handleAction}>Llama2-13b</leo-menu-item>
```

The errors looked something like this:

```
TS2747: 'leo-option' components don't accept text as child elements. Text in JSX has the type 'string', but the expected type of 'children' is '(Snippet<[]> & (string | Element[])) | undefined'.
```

**Solution: Omit the children prop on the imported svelte types in a few areas, this seems to let it use the correct react children prop for types.**

## Details
- Omit `children` in `scripts/gen-react-bindings.js` in the imported svelte component types
- For `leo-menu-item` and `leo-option`:
    - From `HTMLAttributes` type from `svelte/elements` omit the `children` prop
    - Define `children` with the type `string | Elements[]`
- Abstracts the new `HTMLAttributes` to the `components/svelte-react.ts` file 