### PR TITLE
[Svelte5]: Reconcile tailwind differences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@storybook/test": "8.6.14",
-        "svelte": "^5.53.13",
+        "svelte": "5.53.13",
         "svelte-preprocess": "6.0.3",
         "tailwindcss": "3.4.18",
         "tslib": "2.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@storybook/test": "8.6.14",
-        "svelte": "5.1.4",
+        "svelte": "^5.53.13",
         "svelte-preprocess": "6.0.3",
         "tailwindcss": "3.4.18",
         "tslib": "2.8.1"
@@ -102,17 +102,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1710,7 +1699,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -3113,6 +3101,15 @@
         "storybook": "^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0"
       }
     },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
+      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "4.0.0",
       "dev": true,
@@ -3430,6 +3427,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "dev": true,
@@ -3447,6 +3450,19 @@
       "version": "21.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",
@@ -3686,13 +3702,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-typescript": {
-      "version": "1.4.13",
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": ">=8.9.0"
       }
     },
     "node_modules/agent-base": {
@@ -4352,6 +4361,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "dev": true,
@@ -4865,6 +4883,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devalue": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
+      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -5429,6 +5453,7 @@
     },
     "node_modules/esrap": {
       "version": "1.4.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -9109,20 +9134,25 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.1.4",
+      "version": "5.53.13",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.13.tgz",
+      "integrity": "sha512-9P6I/jGcQMzAMb76Uyd6L6RELAC7qt53GOSBLCke9lubh9iJjmjCo+EffRH4gOPnTB/x4RR2Tmt6s3o9ywQO3g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
+        "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.5",
         "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
-        "acorn-typescript": "^1.4.13",
-        "aria-query": "^5.3.1",
+        "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
-        "esm-env": "^1.0.0",
-        "esrap": "^1.2.2",
-        "is-reference": "^3.0.2",
+        "clsx": "^2.1.1",
+        "devalue": "^5.6.4",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.2",
+        "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
         "zimmerframe": "^1.1.2"
@@ -9270,10 +9300,22 @@
       }
     },
     "node_modules/svelte/node_modules/aria-query": {
-      "version": "5.3.2",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/svelte/node_modules/esrap": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
+      "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@typescript-eslint/types": "^8.2.0"
       }
     },
     "node_modules/svelte2tsx": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "dependencies": {
     "@storybook/test": "8.6.14",
-    "svelte": "5.1.4",
+    "svelte": "^5.53.13",
     "svelte-preprocess": "6.0.3",
     "tailwindcss": "3.4.18",
     "tslib": "2.8.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "dependencies": {
     "@storybook/test": "8.6.14",
-    "svelte": "^5.53.13",
+    "svelte": "5.53.13",
     "svelte-preprocess": "6.0.3",
     "tailwindcss": "3.4.18",
     "tslib": "2.8.1"

--- a/src/components/alert/alert.svelte
+++ b/src/components/alert/alert.svelte
@@ -70,7 +70,7 @@
   }
 
   :global(.leo-alert .actions > *),
-  .leo-alert .actions ::slotted(*) {
+  :global(.leo-alert .actions ::slotted(*)) {
     display: flex;
     flex-direction: row;
     gap: var(--leo-spacing-m);

--- a/src/components/alert/alert.svelte
+++ b/src/components/alert/alert.svelte
@@ -69,8 +69,8 @@
     display: block;
   }
 
-  :global(.leo-alert .actions > *),
-  :global(.leo-alert .actions ::slotted(*)) {
+  .leo-alert .actions > :global(*),
+  .leo-alert .actions :global(::slotted(*)) {
     display: flex;
     flex-direction: row;
     gap: var(--leo-spacing-m);

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -188,7 +188,7 @@
      * Should only be necessary for Tailwind consumers where there's
      * no guarantee that the button will contain a child element.
      */
-    &:not(:has(> :global(*))) {
+    &:not(:has(> *)) {
       padding-left: var(
         --leo-button-padding,
         calc(var(--padding-x) + var(--icon-gap))

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -188,7 +188,7 @@
      * Should only be necessary for Tailwind consumers where there's
      * no guarantee that the button will contain a child element.
      */
-    &:not(:has(> *)) {
+    &:not(:has(> :global(*))) {
       padding-left: var(
         --leo-button-padding,
         calc(var(--padding-x) + var(--icon-gap))

--- a/src/components/collapse/collapse.svelte
+++ b/src/components/collapse/collapse.svelte
@@ -181,7 +181,7 @@
     outline: none;
   }
 
-  :global(details[open] .arrow) {
+  &[open] .arrow {
     transform: rotate(180deg);
   }
 }

--- a/src/components/collapse/collapse.svelte
+++ b/src/components/collapse/collapse.svelte
@@ -181,7 +181,7 @@
     outline: none;
   }
 
-  details[open] .arrow {
+  :global(details[open] .arrow) {
     transform: rotate(180deg);
   }
 }

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -250,7 +250,7 @@
   }
 
   :host .leo-dialog .actions,
-  .leo-dialog :global(.actions:has([slot=actions]:not(:empty))) {
+  .leo-dialog .actions:has(:global([slot=actions]:not(:empty))) {
     background: var(--background);
     padding: var(--padding);
   }

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -165,12 +165,12 @@
    * however for webcomponents, we don't need to check for this, so we special
    * case the selector with :host. */
   :host .leo-dialog.hasActions,
-  .leo-dialog.hasActions:has([slot='actions']:not(:empty)) {
+  :global(.leo-dialog.hasActions:has([slot='actions']:not(:empty))) {
     grid-template-rows: auto auto;
   }
 
   :host .leo-dialog.hasHeader.hasActions,
-  .leo-dialog.hasHeader.hasActions:has(.actions [slot='actions']:not(:empty)) {
+  :global(.leo-dialog.hasHeader.hasActions:has(.actions [slot='actions']:not(:empty))) {
     grid-template-rows: auto auto auto;
   }
 
@@ -245,12 +245,12 @@
   }
 
   :host .leo-dialog .actions .body,
-  .leo-dialog.hasActions:has([slot='actions']:not(:empty)) .body {
+  :global(.leo-dialog.hasActions:has([slot='actions']:not(:empty)) .body) {
     padding-bottom: 0;
   }
 
   :host .leo-dialog .actions,
-  .leo-dialog .actions:has([slot='actions']:not(:empty)) {
+  :global(.leo-dialog .actions:has([slot='actions']:not(:empty))) {
     background: var(--background);
     padding: var(--padding);
   }

--- a/src/components/dialog/dialog.svelte
+++ b/src/components/dialog/dialog.svelte
@@ -165,12 +165,12 @@
    * however for webcomponents, we don't need to check for this, so we special
    * case the selector with :host. */
   :host .leo-dialog.hasActions,
-  :global(.leo-dialog.hasActions:has([slot='actions']:not(:empty))) {
+  .leo-dialog.hasActions:has(:global([slot=actions]:not(:empty))) {
     grid-template-rows: auto auto;
   }
 
   :host .leo-dialog.hasHeader.hasActions,
-  :global(.leo-dialog.hasHeader.hasActions:has(.actions [slot='actions']:not(:empty))) {
+  .leo-dialog.hasHeader.hasActions:has(.actions :global([slot=actions]:not(:empty))) {
     grid-template-rows: auto auto auto;
   }
 
@@ -245,12 +245,12 @@
   }
 
   :host .leo-dialog .actions .body,
-  :global(.leo-dialog.hasActions:has([slot='actions']:not(:empty)) .body) {
+  .leo-dialog.hasActions:has(:global([slot=actions]:not(:empty))) .body {
     padding-bottom: 0;
   }
 
   :host .leo-dialog .actions,
-  :global(.leo-dialog .actions:has([slot='actions']:not(:empty))) {
+  .leo-dialog :global(.actions:has([slot=actions]:not(:empty))) {
     background: var(--background);
     padding: var(--padding);
   }
@@ -263,8 +263,8 @@
     *
     * The :global selector doesn't seem to be able to handle nesting, so we have
     * two separate selectors for mobile & non-mobile layouts */
-  :global(.leo-dialog .actions ::slotted(*)),
-  :global(.leo-dialog .actions [slot='actions']:not(:empty)) {
+  .leo-dialog .actions :global(::slotted(*)),
+  .leo-dialog .actions :global([slot='actions']:not(:empty)) {
     display: flex;
     gap: var(--leo-spacing-xl);
     flex-direction: column;

--- a/src/components/formItem/formItem.svelte
+++ b/src/components/formItem/formItem.svelte
@@ -180,7 +180,7 @@
         border-color: var(--border-color-hover);
       }
 
-      & :global(.container:has(*:focus-visible)),
+      & .container:has(:global(*:focus-visible)),
       &.isFocused .container {
         &:not(:has(.extra-content:focus-within)) {
           color: var(--color-focus);
@@ -194,7 +194,7 @@
         color: var(--leo-color-systemfeedback-error-icon);
       }
 
-      &.error :global(.container:hover:not(:has(*:focus-visible))) {
+      &.error .container:hover:not(:has(:global(*:focus-visible))) {
         border-color: var(--border-color-error-hover);
       }
     }

--- a/src/components/formItem/formItem.svelte
+++ b/src/components/formItem/formItem.svelte
@@ -180,7 +180,7 @@
         border-color: var(--border-color-hover);
       }
 
-      & .container:has(*:focus-visible),
+      & :global(.container:has(*:focus-visible)),
       &.isFocused .container {
         &:not(:has(.extra-content:focus-within)) {
           color: var(--color-focus);
@@ -194,7 +194,7 @@
         color: var(--leo-color-systemfeedback-error-icon);
       }
 
-      &.error .container:hover:not(:has(*:focus-visible)) {
+      &.error :global(.container:hover:not(:has(*:focus-visible))) {
         border-color: var(--border-color-error-hover);
       }
     }


### PR DESCRIPTION
# What?

After upgrading to Svelte 5, the compiler was removing several selectors from the compiled Tailwind tokens during tree-shaking that were present in the result from the previous version. This PR restores those selectors for proper styling.

## Details
-  Adds a global selector in `src/components/alert/alert.svelte` to fix this diff: <img width="765" height="90" alt="image" src="https://github.com/user-attachments/assets/edc4c35e-38f7-4f36-a3a0-e11dd74550b7" />

- Adds a global selector in `src/components/collapse/collapse.svelte` to fix this diff: <img width="765" height="90" alt="image" src="https://github.com/user-attachments/assets/ac3b80d0-1a80-4c54-a947-f1e1ae2bd01c" />

- Adds 4 global selectors in `src/components/dialog/dialog.svelte` to fix these diffs: <img width="765" height="90" alt="image" src="https://github.com/user-attachments/assets/667b9eb3-ce01-4852-b92f-9fdcd776bc84" /> <img width="765" height="90" alt="image" src="https://github.com/user-attachments/assets/35ac091d-08ac-4695-a516-4e261d4f30bc" />

- Adds 2 global selectors in `src/components/dialog/dialog.svelte` to fix a missing wildcard on `*:focus-visible`: <img width="765" height="86" alt="image" src="https://github.com/user-attachments/assets/90f88cc4-f276-4b15-b983-b30ad6f0c935" />

