### PR TITLE
Fix complex types in react

### DIFF
--- a/examples/example-ui-react/src/App.tsx
+++ b/examples/example-ui-react/src/App.tsx
@@ -9,6 +9,19 @@ import Dropdown from '@brave/leo/react/dropdown'
 import ButtonMenu from '@brave/leo/react/buttonMenu'
 import Toggle from '@brave/leo/react/toggle'
 import Icon from '@brave/leo/react/icon'
+import Link from '@brave/leo/react/link'
+import Alert from '@brave/leo/react/alert'
+import Checkbox from '@brave/leo/react/checkbox'
+import Collapse from '@brave/leo/react/collapse'
+import Dialog from '@brave/leo/react/dialog'
+import Label from '@brave/leo/react/label'
+import NavDots from '@brave/leo/react/navdots'
+import ProgressBar from '@brave/leo/react/progressBar'
+import ProgressRing from '@brave/leo/react/progressRing'
+import RadioButton from '@brave/leo/react/radioButton'
+import SegmentedControl from '@brave/leo/react/segmentedControl'
+import SegmentedControlItem from '@brave/leo/react/segmentedControlItem'
+import TextArea from '@brave/leo/react/textarea'
 
 import '@fontsource/poppins/500.css'
 import '@fontsource/poppins/600.css'
@@ -19,15 +32,61 @@ function App() {
   const [buttonText, setButtonText] = React.useState('I am a LEO Button')
   const [spinning, setSpinning] = React.useState(false)
   const [isThing, setIsThing] = React.useState(false)
+  const [activeDot, setActiveDot] = React.useState(0)
+  const [radioButtonValue, setRadioButtonValue] = React.useState("radio 1")
+  const [segmentedControlValue, setSegmentedControlValue] = React.useState<string | undefined>("full")
+  const [collapsableOpen, toggleCollapsable] = React.useReducer(
+    (state) => !state,
+    false
+  )
+  const [dialogOpen, toggleDialogOpen] = React.useReducer(
+    (state) => !state,
+    false
+  )
 
   const handleAction = () => console.log('action')
 
   return (
     <>
+      <Alert>Alert content</Alert>
+      <Dialog isOpen={dialogOpen} onClose={toggleDialogOpen}>
+        Dialog content
+      </Dialog>
       <header>
         <h1>A React App</h1>
+        <NavDots onChange={(dot) => setActiveDot(dot.activeDot)} activeDot={activeDot} dotCount={10} />
       </header>
-      <section>
+      <section style={{ marginTop: '1.5rem', display: 'flex', alignItems: 'stretch', gap: '1.5rem'}}>
+        <SegmentedControl value={segmentedControlValue} onChange={(evt) => setSegmentedControlValue(evt.value)}>
+          <SegmentedControlItem value="full">
+            <Icon slot="icon-before" name="check-circle-outline" />
+            Full
+          </SegmentedControlItem>
+
+          <SegmentedControlItem value="simple">
+            <Icon slot="icon-before" name="check-circle-outline" />
+            Simple
+          </SegmentedControlItem>
+        </SegmentedControl>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <RadioButton value="radio 1" onChange={(evt) => setRadioButtonValue(evt.value)} name="radio-component" currentValue={radioButtonValue} size="small" />
+          <RadioButton value="radio 2" onChange={(evt) => setRadioButtonValue(evt.value)} name="radio-component" currentValue={radioButtonValue} size="small" />
+        </div>
+        <TextArea>Text Area</TextArea>
+        <ProgressRing />
+        <ProgressBar progress={0.5} />
+        <LeoButton onClick={toggleDialogOpen}>Open Dialog</LeoButton>
+        <Collapse
+          title="A Collapsable"
+          isOpen={collapsableOpen}
+          onToggle={toggleCollapsable}
+        >
+          Collapsable Content
+        </Collapse>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <Checkbox checked /> Checkbox
+        </div>
+        <Label color="secondary">Label Content</Label>
         <Input value={buttonText} onInput={(e: any) => setButtonText(e.value)}>
           Edit the button text:
           {buttonText.length % 2 === 0 && (
@@ -91,6 +150,9 @@ function App() {
         <Tooltip text="Hello World">
           <LeoButton href="#foo">Link button!</LeoButton>
         </Tooltip>
+        <Link href="https://brave.com">Link as anchor tag</Link>
+        <Link type="submit">Link as button</Link>
+        <LeoButton href="https://brave.com">Button as anchor tag</LeoButton>
       </section>
     </>
   )

--- a/src/components/button/button.svelte
+++ b/src/components/button/button.svelte
@@ -19,37 +19,28 @@
   type Href = $$Generic<string | undefined>
   type Disabled = $$Generic<undefined extends Href ? boolean : undefined>
   type Loading = $$Generic<undefined extends Href ? boolean : undefined>
+  type ExcludedProps = 'size' | 'href' | 'hreflang'
 
   interface CommonProps {
-    kind?: Props.ButtonKind;
-    size?: Props.ButtonSize;
-    fab?: boolean;
-    onClick?: (e: MouseEvent) => void;
+    kind?: Props.ButtonKind
+    size?: Props.ButtonSize
+    fab?: boolean
+    onClick?: (e: MouseEvent) => void
   }
 
-  type ButtonHTMLAttributes = Pick<
-    SvelteHTMLElements['button'],
-    'id' | 'class' | 'style' | 'disabled' | 'type' | 'aria-label'
-  >;
+  type NalaButtonProps = CommonProps &
+    Omit<Partial<SvelteHTMLElements['button']>, ExcludedProps> & {
+      isDisabled?: Disabled
+      isLoading?: Loading
+      href?: never
+    }
 
-  type LinkHTMLAttributes = Pick<
-    SvelteHTMLElements['a'],
-    'id' | 'class' | 'style' | 'target' | 'rel' | 'aria-label'
-  >;
+  type NalaLinkProps = CommonProps &
+    Omit<Partial<SvelteHTMLElements['a']>, ExcludedProps> & {
+      href: Href
+    }
 
-  type NalaButtonProps = CommonProps & {
-    isDisabled?: Disabled
-    isLoading?: Loading
-    href?: never
-  } & Partial<ButtonHTMLAttributes>;
-
-  type NalaLinkProps = CommonProps & {
-    href: string | undefined;
-    isDisabled?: never;
-    isLoading?: never;
-  } & Partial<LinkHTMLAttributes>;
-
-  type $$Props = NalaButtonProps | NalaLinkProps;
+  type $$Props = NalaLinkProps | NalaButtonProps
 
   export let kind: Props.ButtonKind = 'filled'
   export let size: Props.ButtonSize = 'medium'

--- a/src/scripts/gen-react-bindings.js
+++ b/src/scripts/gen-react-bindings.js
@@ -39,6 +39,14 @@ const getComponentGenerics = async (svelteFilePath, componentName) => {
   )
 }
 
+// For a conditional constraint like "undefined extends Href ? boolean : undefined",
+// return the union of both branches ("boolean | undefined"). This lets us substitute
+// a concrete upper bound so TypeScript doesn't need to evaluate a conditional chain.
+const upperBound = (constraint) => {
+  const m = constraint?.match(/\?(.+):(.+)$/)
+  return m ? `${m[1].trim()} | ${m[2].trim()}` : constraint ?? 'any'
+}
+
 const getReactFileContents = async (svelteFilePath) => {
   // for example:
   // ./src/components/button/button.svelte ==> button
@@ -69,7 +77,27 @@ export default SvelteToReact('${COMPONENT_PREFIX}-${fileNameWithoutExtension.toL
 export * from '../web-components/${fileNameWithoutExtension}.js'
     `.trim()
 
-  const typeDef = `
+  const hasConditionalConstraints = generics.some((genericType) =>
+    genericType.constraint?.includes('?')
+  )
+
+  // When any generic has a conditional constraint (e.g. `undefined extends Href ?
+  // boolean : undefined`), threading those params through ReactProps causes TypeScript
+  // to hit the instantiation depth limit. Instead, substitute each generic with its
+  // upper bound (union of both branches) to produce a concrete, resolvable type.
+  const typeDef = hasConditionalConstraints
+    ? `
+import type * as React from 'react'
+import type { ReactProps } from '../src/components/svelte-react'
+import type { ${componentName}Props as SvelteProps } from '../types/src/components/${containingFolder}/${fileName}';
+export type ${componentName}Props = ReactProps<Omit<SvelteProps<${generics.map((genericType) => upperBound(genericType.constraint)).join(', ')}>, 'children'>>;
+export default function ${componentName}(props: React.PropsWithChildren<${componentName}Props>): JSX.Element
+
+// As we don't currently have type definitions for the web components, export
+// the Type Definitions from the Svelte component.
+export * from '../types/src/components/${containingFolder}/${fileName}'
+      `.trim()
+    : `
 import type * as React from 'react'
 import type { ReactProps } from '../src/components/svelte-react'
 import type { ${componentName}Props as SvelteProps } from '../types/src/components/${containingFolder}/${fileName}';
@@ -79,7 +107,7 @@ export default function ${componentName}${funcConstraints}(props: React.PropsWit
 // As we don't currently have type definitions for the web components, export
 // the Type Definitions from the Svelte component.
 export * from '../types/src/components/${containingFolder}/${fileName}'
-    `.trim()
+      `.trim()
 
   return [binding, typeDef]
 }


### PR DESCRIPTION
# What?

Button and Link use `$$Generic` with conditional constraints that, when threaded through ReactProps, cause TS to hit its instantiation depth limit. In Svelte 5 this caused a complex union type error in the React bindings because `svelte2tsx` carries those conditional constraints verbatim into the generated types, and the React wrapper stacks them into a chain of conditionals that TS can't resolve.

Fix: gen-react-bindings.js now detects generics with conditional constraints and substitutes each with its upper bound (union of both conditional branches), emitting a concrete type instead of a generic one. Covers all affected components automatically.


Also, in `examples/example-ui-react/src/App.tsx`,  I added a bunch of test components (Link, Button, Alert, Dialog, Collapse, etc.) as tests for the same issue.